### PR TITLE
WETH CHECK

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,8 +11,23 @@ async function operation(acc) {
     await core.connectWallet();
     await core.getBalance();
 
-    if (core.balance.ETH < 0.0015)
-      throw Error("Minimum Eth Balance Is 0.0015 ETH");
+    if (core.balance.ETH < 0.0015) {
+      if (core.balance.WETH > 0.0001) {
+        try {
+          await core.withdraw();
+        } catch (error) {
+          await Helper.delay(
+            3000,
+            acc,
+            `Error during deposit/withdraw operation: ${error.message}`,
+            core
+          );
+        }
+      } else {
+        throw Error( "Balance is less than 0.0015 ETH, please fill up your balance"); 
+      }
+    }
+    
     for (const count of Array(Config.WRAPUNWRAPCOUNT)) {
       if (core.balance.ETH < 0.0015)
         throw Error(


### PR DESCRIPTION
I often make a running bot mistake where I stop when my WETH balance is still a lot and has not been returned to eth, here I add when the balance is below the minimum, there is a WETH check first so that WETH is returned to ETH to be able to continue the transaction.